### PR TITLE
test: Add save test failures

### DIFF
--- a/airbnb/dbt_project.yml
+++ b/airbnb/dbt_project.yml
@@ -36,3 +36,7 @@ models:
       +materialized: table
     src:
       +materialized: ephemeral
+
+data_tests:
+  +store_failures: true
+  +schema: _test_failures


### PR DESCRIPTION
### Release: 1.3.4

Tests:
- AIRBNB._test_failure: new schema for saving test failures